### PR TITLE
Fix line breaks in printing a calendar

### DIFF
--- a/when
+++ b/when
@@ -2055,7 +2055,6 @@ sub make_one_month_calendar {
   }
   my $this_month = $when->m;
   while ($when->m == $this_month) {
-    if ($when->day_of_week==1) {push @cal,$line; $line = ''}
     my $display = sprintf('%2d',$when->d);
     if ($when->compare($today)==0 && $mark_today) {
       if ($args{WANT_STYLING} && $args{TODAY_STYLE} ne '') {
@@ -2067,6 +2066,9 @@ sub make_one_month_calendar {
     }
     $line = "$line$display ";
     $when->increment_day_in_place();
+    # The first day of a second and the subsequent weeks in this month
+    # will be printed on the next line in the calendar
+    if ($when->day_of_week==1) {push @cal,$line; $line = ''}
   }
   if ($line ne '') {push @cal,$line; $line = ''}
 


### PR DESCRIPTION
This fixes #1.

A line break must not be put before the first day of a week if it is the first day of the month at the same time. That would result in an extra empty line.
